### PR TITLE
Add Travis-CI to JUnit project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: java
+sudo: false
+
+jdk:
+  - oraclejdk8
+
+script:
+  - cd JUnit
+  - mvn clean test
+
+#after_success:
+#- mvn clean cobertura:cobertura coveralls:report -Ptravis-cobertura


### PR DESCRIPTION
Here's the initial build configuration for the JUnit maven project.

We can just add more to the script key in the YAML file to build the other JUnitTester project (wasn't sure if it was necessary).

After merging it, one would need to log in to Travis CI and enable it for this repository.

HTH,
Bruno